### PR TITLE
Save memory with prototypes

### DIFF
--- a/lib/lazy-bones.ts
+++ b/lib/lazy-bones.ts
@@ -1,12 +1,11 @@
 import { DataSourceSpec, DataSetConstructor } from './model';
 import Orchestrator from './orchestrator';
+import Orchestration from './orchestration';
 
 function LazyBones<T, U>(spec: DataSourceSpec<T, U>) : DataSetConstructor<T, U> {
   const orchestrator = new Orchestrator(spec);
 
-  let constructor = data => orchestrator.getInstance(data);
-
-  return Object.setPrototypeOf(constructor, orchestrator.emitter);
+  return Object.setPrototypeOf(Orchestration(orchestrator), orchestrator.emitter);
 }
 
 export default LazyBones;

--- a/lib/orchestration.ts
+++ b/lib/orchestration.ts
@@ -1,0 +1,33 @@
+import * as Promise from 'bluebird';
+
+import Orchestrator from "./orchestrator";
+import { DataSet } from "./model";
+
+function Orchestration<T, U>(orchestrator: Orchestrator<T, U>) : ((initialData : { [K in keyof T]?: T[K] }) => DataSet<T>) {
+
+  function Constructor(initialData: { [K in keyof T]?: T[K] }) {
+    this.cache = Object.assign({}, initialData || {});
+  }
+
+  Constructor.prototype = orchestrator.mapSpec(key => function(cb) {
+    return orchestrator.resolve(key, this.cache, cb);
+  });
+
+  Object.assign(Constructor.prototype, {
+    get(...args) {
+      if (typeof(args[args.length - 1]) === 'function') {
+        return Promise.resolve(orchestrator.fetchDependentResult(this.cache, null, args.slice(0, -1), results => results))
+          .asCallback(args[args.length - 1]);
+      } else {
+        return orchestrator.fetchDependentResult(this.cache, null, args, results => results);
+      }
+    },
+    toJSON() {
+      return this.cache;
+    }
+  });
+
+  return data => new Constructor(data);
+}
+
+export default Orchestration;

--- a/lib/orchestrator.ts
+++ b/lib/orchestrator.ts
@@ -3,7 +3,7 @@ import * as Promise from 'bluebird';
 import {
   DataSourceSpec,
   Dependencies, DependentFetchFn, FetchFnWithDeps,
-  DataSet, TypedEventEmitter, TimingEvent
+  TypedEventEmitter, TimingEvent
 } from './model';
 import mapObject from './map-object';
 
@@ -75,10 +75,6 @@ class Orchestrator<T, U> {
     }
 
     return { dependencies, fn };
-  }
-
-  getInstance(values) {
-    return Orchestration<T, U>(this, values || {});
   }
 
   resolve(key, cache, cb?) {
@@ -198,30 +194,6 @@ class Orchestrator<T, U> {
   mapSpec(fn) {
     return mapObject(this.spec, fn);
   }
-}
-
-function Orchestration<T, U>(orchestrator: Orchestrator<T, U>, initialData: { [K in keyof T]?: T[K] }) : DataSet<T> {
-  const cache = initialData;
-
-  const methods: { [K in keyof T]?: Promise<T[K]> } = orchestrator.mapSpec(key => {
-    return cb => {
-      return orchestrator.resolve(key, cache, cb);
-    };
-  });
-
-  return Object.assign(methods, {
-    get(...args) {
-      if (typeof(args[args.length - 1]) === 'function') {
-        return Promise.resolve(orchestrator.fetchDependentResult(cache, null, args.slice(0, -1), results => results))
-          .asCallback(args[args.length - 1]);
-      } else {
-        return orchestrator.fetchDependentResult(cache, null, args, results => results);
-      }
-    },
-    toJSON() {
-      return cache;
-    }
-  });
 }
 
 export default Orchestrator;


### PR DESCRIPTION
Currently, this implementation is really inefficient and is probably leading to circular references the GC can't untangle. Each instance of a data set is being created with its own unique method objects, referencing a cache inside of a closure. With these changes, now each data source creates all methods in one prototype, and each data set is just an object with a cache property deriving from that prototype.